### PR TITLE
Add ability to remove event listeners on FusionPoseSensor.js

### DIFF
--- a/src/sensor-fusion/fusion-pose-sensor.js
+++ b/src/sensor-fusion/fusion-pose-sensor.js
@@ -28,8 +28,7 @@ function FusionPoseSensor() {
   this.accelerometer = new MathUtil.Vector3();
   this.gyroscope = new MathUtil.Vector3();
 
-  window.addEventListener('devicemotion', this.onDeviceMotionChange_.bind(this));
-  window.addEventListener('orientationchange', this.onScreenOrientationChange_.bind(this));
+  this.start();
 
   this.filter = new ComplementaryFilter(WebVRConfig.K_FILTER);
   this.posePredictor = new PosePredictor(WebVRConfig.PREDICTION_TIME_S);
@@ -178,6 +177,19 @@ FusionPoseSensor.prototype.setScreenTransform_ = function() {
   }
   this.inverseWorldToScreenQ.copy(this.worldToScreenQ);
   this.inverseWorldToScreenQ.inverse();
+};
+
+FusionPoseSensor.prototype.start = function() {
+  this.onDeviceMotionCallback_ = this.onDeviceMotionChange_.bind(this);
+  this.onScreenOrientationCallback_ = this.onScreenOrientationChange_.bind(this);
+  
+  window.addEventListener('devicemotion', this.onDeviceMotionCallback_);
+  window.addEventListener('orientationchange', this.onScreenOrientationCallback_);
+};
+
+FusionPoseSensor.prototype.stop = function() {
+  window.removeEventListener('devicemotion', this.onDeviceMotionCallback_);
+  window.removeEventListener('orientationchange', onScreenOrientationCallback_);
 };
 
 module.exports = FusionPoseSensor;

--- a/src/sensor-fusion/fusion-pose-sensor.js
+++ b/src/sensor-fusion/fusion-pose-sensor.js
@@ -189,7 +189,7 @@ FusionPoseSensor.prototype.start = function() {
 
 FusionPoseSensor.prototype.stop = function() {
   window.removeEventListener('devicemotion', this.onDeviceMotionCallback_);
-  window.removeEventListener('orientationchange', onScreenOrientationCallback_);
+  window.removeEventListener('orientationchange', this.onScreenOrientationCallback_);
 };
 
 module.exports = FusionPoseSensor;


### PR DESCRIPTION
Hey, great work on the polyfill! I'm using just the pose sensor part of the project at the moment which is really useful but I noticed it carries on listening for motion events after it's destroyed so I've added a method to stop or start them again. Hopefully you find it useful, let me know your thoughts.
Thanks,
Al
