### PR TITLE
Use the padding only under iOS especially if it is only for iPhone 5.

### DIFF
--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -1682,12 +1682,11 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
     // hide the URL bar unless content is bigger than the screen.
     // This will not be visible as long as the container element (e.g. body)
     // is set to 'overflow: hidden'.
-    var padding;
+    var padding = '0';
     if (Util.isIOS()) {
       padding = '0 10px 10px 0';
-    } else {
-      padding = '0';
     }
+
     var cssProperties = [
       'position: absolute',
       'top: 0',

--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -1682,6 +1682,12 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
     // hide the URL bar unless content is bigger than the screen.
     // This will not be visible as long as the container element (e.g. body)
     // is set to 'overflow: hidden'.
+    var padding;
+    if (Util.isIOS()) {
+      padding = '0 10px 10px 0';
+    } else {
+      padding = '0';
+    }
     var cssProperties = [
       'position: absolute',
       'top: 0',
@@ -1690,7 +1696,7 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
       'height: ' + Math.min(screen.height, screen.width) + 'px',
       'border: 0',
       'margin: 0',
-      'padding: 0 10px 10px 0',
+      'padding:' + padding,
     ];
     gl.canvas.setAttribute('style', cssProperties.join('; ') + ';');
 

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -236,6 +236,12 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
     // hide the URL bar unless content is bigger than the screen.
     // This will not be visible as long as the container element (e.g. body)
     // is set to 'overflow: hidden'.
+    var padding;
+    if (Util.isIOS()) {
+      padding = '0 10px 10px 0';
+    } else {
+      padding = '0';
+    }
     var cssProperties = [
       'position: absolute',
       'top: 0',
@@ -244,7 +250,7 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
       'height: ' + Math.min(screen.height, screen.width) + 'px',
       'border: 0',
       'margin: 0',
-      'padding: 0 10px 10px 0',
+      'padding:' + padding,
     ];
     gl.canvas.setAttribute('style', cssProperties.join('; ') + ';');
 

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -236,12 +236,11 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
     // hide the URL bar unless content is bigger than the screen.
     // This will not be visible as long as the container element (e.g. body)
     // is set to 'overflow: hidden'.
-    var padding;
+    var padding = '0';
     if (Util.isIOS()) {
       padding = '0 10px 10px 0';
-    } else {
-      padding = '0';
     }
+
     var cssProperties = [
       'position: absolute',
       'top: 0',


### PR DESCRIPTION
Without these changes the 10px padding occurs on my Sony Xperia Z5 when starting the VR in Portrait mode and it won't go away. So just use it on iOS if it is only for iPhone 5