### PR TITLE
Resize the real canvas through the patched canvas width/height properties

### DIFF
--- a/src/cardboard-distorter.js
+++ b/src/cardboard-distorter.js
@@ -249,6 +249,7 @@ CardboardDistorter.prototype.patch = function() {
       },
       set: function(value) {
         self.bufferWidth = value;
+        self.realCanvasWidth.set.call(canvas, value);
         self.onResize();
       }
     });
@@ -261,6 +262,7 @@ CardboardDistorter.prototype.patch = function() {
       },
       set: function(value) {
         self.bufferHeight = value;
+        self.realCanvasHeight.set.call(canvas, value);
         self.onResize();
       }
     });


### PR DESCRIPTION
Fixes issues when using with PlayCanvas with device pixel ratio.

Seems be due to us resizing the canvas after the patch is applied which is then not passed on to the actual canvas.

Fixes #130