### PR TITLE
Fixed error in strict mode

### DIFF
--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -5371,7 +5371,7 @@ Util.frameDataFromPose = (function() {
     return out;
   };
 
-  mat4_invert = function(out, a) {
+  function mat4_invert(out, a) {
     var a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3],
         a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7],
         a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11],

--- a/src/util.js
+++ b/src/util.js
@@ -313,7 +313,7 @@ Util.frameDataFromPose = (function() {
     return out;
   };
 
-  mat4_invert = function(out, a) {
+  function mat4_invert (out, a) {
     var a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3],
         a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7],
         a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11],

--- a/src/util.js
+++ b/src/util.js
@@ -313,7 +313,7 @@ Util.frameDataFromPose = (function() {
     return out;
   };
 
-  function mat4_invert (out, a) {
+  function mat4_invert(out, a) {
     var a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3],
         a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7],
         a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11],


### PR DESCRIPTION
The function `mat4_invert` was being assigned to a variable that was not declared, causing errors when in strict mode. It caused me problems when importing the module with Rollup.