### PR TITLE
Add Note 5 user agent variant to Dpdb cache

### DIFF
--- a/src/dpdb/dpdb-cache.js
+++ b/src/dpdb/dpdb-cache.js
@@ -662,6 +662,17 @@ var DPDB_CACHE = {
   {
     "type": "android",
     "rules": [
+      { "mdmh": "samsung/*/SM-N920W8/*" },
+      { "ua": "SM-N920W8" }
+    ],
+    "dpi": [ 515.1, 518.4 ],
+    "bw": 3,
+    "ac": 1000
+  },
+    
+  {
+    "type": "android",
+    "rules": [
       { "mdmh": "samsung/*/GT-I9300I/*" },
       { "ua": "GT-I9300I" }
     ],


### PR DESCRIPTION
We found that for one of our devices (a Samsung Note 5) the distortions were not being applied correctly, the reason being that the model number is "SM-N920W8" for Canadian devices.