### PR TITLE
Add uglifyjs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "devDependencies": {
     "browserify": "latest",
     "derequire": "latest",
-    "watchify": "latest"
+    "watchify": "latest",
+    "uglifyjs": "latest"
   },
   "main": "build/webvr-polyfill.js",
   "keywords": [


### PR DESCRIPTION
In order to run the `min` npm script one has to have `uglifyjs` on their machine. Ideally it is part of the dependencies like the other tools used.