### PR TITLE
Updated dpdb (adding Pixel)

### DIFF
--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -43,7 +43,7 @@ function CardboardVRDisplay() {
   this.distorter_ = null;
   this.cardboardUI_ = null;
 
-  this.dpdb_ = new Dpdb(true, this.onDeviceParamsUpdated_.bind(this));
+  this.dpdb_ = new Dpdb(false, this.onDeviceParamsUpdated_.bind(this));
   this.deviceInfo_ = new DeviceInfo(this.dpdb_.getDeviceParams());
 
   this.viewerSelector_ = new ViewerSelector();

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -43,7 +43,7 @@ function CardboardVRDisplay() {
   this.distorter_ = null;
   this.cardboardUI_ = null;
 
-  this.dpdb_ = new Dpdb(false, this.onDeviceParamsUpdated_.bind(this));
+  this.dpdb_ = new Dpdb(true, this.onDeviceParamsUpdated_.bind(this));
   this.deviceInfo_ = new DeviceInfo(this.dpdb_.getDeviceParams());
 
   this.viewerSelector_ = new ViewerSelector();

--- a/src/dpdb/dpdb-cache.js
+++ b/src/dpdb/dpdb-cache.js
@@ -57,6 +57,17 @@ var DPDB_CACHE = {
   {
     "type": "android",
     "rules": [
+      { "mdmh": "Google//Pixel/" },
+      { "ua": "Pixel" }
+    ],
+    "dpi": [432.6, 436.7],
+    "bw": 3,
+    "ac": 1000
+  },
+
+  {
+    "type": "android",
+    "rules": [
       { "mdmh": "HTC/*/HTC6435LVW/*" },
       { "ua": "HTC6435LVW" }
     ],


### PR DESCRIPTION
Pixel XL is in the database, however Pixel was not covered, and was logging "No DPDB device match".

Also I would like to recommend that https://storage.googleapis.com/cardboard-dpdb/dpdb.json be updated -- as of this pull request it is at least 2 versions behind (let me know if there should be a separate issue for this).