### PR TITLE
Fix VRLayer bounds regression

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -217,12 +217,8 @@ VRDisplay.prototype.requestPresent = function(layers) {
       }
 
       for (var i = 0; i < 4; i++) {
-        if (layer.leftBounds[i] !== leftBounds[i]) {
-          layer.leftBounds[i] = leftBounds[i];
-        }
-        if (layer.rightBounds[i] !== rightBounds[i]) {
-          layer.rightBounds[i] = rightBounds[i];
-        }
+        layer.leftBounds[i] = leftBounds[i];
+        layer.rightBounds[i] = rightBounds[i];
       }
 
       resolve();

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -201,6 +201,7 @@ CardboardVRDisplay.prototype.endPresent_ = function() {
 
 CardboardVRDisplay.prototype.submitFrame = function(pose) {
   if (this.distorter_) {
+    this.updateBounds_();
     this.distorter_.submitFrame();
   } else if (this.cardboardUI_ && this.layer_) {
     // Hack for predistorted: true.


### PR DESCRIPTION
In #135, we added support for configuring VRLayer bounds on the fly by calling `requestPresent` even after presentation has started. This feature was broken by ed61b1dfdfcee26b68b0fb4b5cd52d949bdce45f, which stopped layer changed from firing an event, per the spec at the time (I think).

This commit restores the feature by updating layer bounds every time `submitFrame` is called, without firing the event. This should not be too costly, since it's just copying 8 floats between arrays with fixed indices.

Note: This patch does not include an updated build.