### PR TITLE
add node require regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
   },
   "devDependencies": {
     "browserify": "latest",
+    "chai": "^3.5.0",
     "derequire": "latest",
-    "watchify": "latest",
-    "uglifyjs": "latest"
+    "jsdom": "^9.12.0",
+    "mocha": "^3.2.0",
+    "uglifyjs": "latest",
+    "watchify": "latest"
   },
   "main": "build/webvr-polyfill.js",
   "keywords": [
@@ -26,7 +29,8 @@
   "scripts": {
     "watch": "watchify src/main.js --standalone WebVRPolyfill -v -d -o 'derequire > build/webvr-polyfill.js'",
     "build": "browserify src/main.js --standalone WebVRPolyfill | derequire > build/webvr-polyfill.js",
-    "min": "browserify src/main.js --standalone WebVRPolyfill | derequire | uglifyjs -c > build/webvr-polyfill.min.js"
+    "min": "browserify src/main.js --standalone WebVRPolyfill | derequire | uglifyjs -c > build/webvr-polyfill.min.js",
+    "test": "mocha"
   },
   "repository": "googlevr/webvr-polyfill",
   "bugs": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,33 @@
+const path = require('path');
+const expect = require('chai').expect;
+const jsdom = require('jsdom');
+
+describe('node acceptance tests', function() {
+  let _window;
+
+  beforeEach(function() {
+    _window = global.window = jsdom.jsdom().defaultView;
+    global.navigator = _window.navigator;
+    global.document = _window.document;
+    Object.defineProperty(_window, 'WebVRConfig', {
+      get() {
+        return global.WebVRConfig;
+      },
+      set(WebVRConfig) {
+        global.WebVRConfig = WebVRConfig;
+      }
+    });
+  });
+
+  afterEach(function() {
+    delete global.window;
+    delete global.document;
+    delete global.WebVRConfig;
+  });
+
+  it('can run in node', function() {
+    require(path.join(process.cwd(), 'src', 'main'));
+
+    expect(_window.VRDisplay).to.be.ok;
+  });
+});


### PR DESCRIPTION
In A-Frame, it is now possible to require aframe in node. This is useful for certain scenarios, such as isomorphic apps.

I would like to add a regression test that preserves the ability to require webvr-polyfill. We have something similar [here](https://github.com/aframevr/aframe/blob/master/tests/node/test.js#L32-L34).

cc @dmarcos @ngokevin 