### PR TITLE
Fix for visible padding when entering VR from portrait mode

### DIFF
--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -237,6 +237,8 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
     // hide the URL bar unless content is bigger than the screen.
     // This will not be visible as long as the container element (e.g. body)
     // is set to 'overflow: hidden'.
+    // Additionally, 'box-sizing: content-box' ensures renderWidth = width + padding.
+    // This is required when 'box-sizing: border-box' is used elsewhere in the page.
     var cssProperties = [
       'position: absolute',
       'top: 0',
@@ -246,6 +248,7 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
       'border: 0',
       'margin: 0',
       'padding: 0 10px 10px 0',
+      'box-sizing: content-box',
     ];
     gl.canvas.setAttribute('style', cssProperties.join('; ') + ';');
 


### PR DESCRIPTION
This pull request is the same as #195 but with some additional comments added and no build file changes to make the merge easier since its seems like the original author is not updating the issue anymore.

It fixes a common issue (which can be see on the live webvr.info samples) introduced by #131 that happens if the page uses 'box-sizing: border-box' and the user enters VR from portrait mode.  Using border-box was causing the padding added by #131 to visible on both iOS and Android and breaking the cardboard setup and nullifying the intent of the fix. Border-box is a pretty common css reset trick these days so it is not uncommon to run into this issue. Visiting any of the webvr.info samples and entering VR from portrait on just about any mobile device will show the issue.

I have personally tested this fix on the following physical devices:

Pixel/Pixel XL
Nexus 5/6/5x/6P
Samsung S6
iPhone 5/6/7

As well as on the iOS simulator for various devices and various iOS versions.