### PR TITLE
Fix for cardboard UI sizes when entering VR from portrait mode

### DIFF
--- a/src/cardboard-ui.js
+++ b/src/cardboard-ui.js
@@ -150,13 +150,12 @@ CardboardUI.prototype.onResize = function() {
 
     var midline = gl.drawingBufferWidth / 2;
 
-    // Assumes your canvas width and height is scaled proportionately.
-    // TODO(smus): The following causes buttons to become huge on iOS, but seems
-    // like the right thing to do. For now, added a hack. But really, investigate why.
-    var dps = (gl.drawingBufferWidth / (screen.width * window.devicePixelRatio));
-    if (!Util.isIOS()) {
-      dps *= window.devicePixelRatio;
-    }
+    // The gl buffer size will likely be smaller than the physical pixel count.
+    // So we need to scale the dps down based on the actual buffer size vs physical pixel count.
+    // This will properly size the ui elements no matter what the gl buffer resolution is
+    var physicalPixels = Math.max(screen.width, screen.height) * window.devicePixelRatio;
+    var scalingRatio = gl.drawingBufferWidth / physicalPixels;
+    var dps = scalingRatio *  window.devicePixelRatio;
 
     var lineWidth = kCenterLineThicknessDp * dps / 2;
     var buttonSize = kButtonWidthDp * kTouchSlopFactor * dps;


### PR DESCRIPTION
This fix slightly changes the way dps for the cardboard UI sizing is calculated for Android and iOS devices. When entering from portrait mode the screen.width will be the smaller dimension and this was throwing off the calculation. The code that was previously in place caused very large UI elements when entering from portrait on android devices. With this change, the same code works correctly on both iOS and Android devices. I also added some comments to explain the calculation a bit.

I've testing this a the following physical devices:

Pixel, Pixel XL, Nexus 5/6/5X/6P, Samsung S6, iPhone 5/6/7

as well as the iOS simulator for various devices.

