### PR TITLE
Make sure ViewerSelector.selectedKey always has a default value

### DIFF
--- a/src/viewer-selector.js
+++ b/src/viewer-selector.js
@@ -27,13 +27,18 @@ var CLASS_NAME = 'webvr-polyfill-viewer-selector';
  * saving the currently selected index in localStorage.
  */
 function ViewerSelector() {
-  // Try to load the selected key from local storage. If none exists, use the
-  // default key.
+  // Try to load the selected key from local storage.
   try {
-    this.selectedKey = localStorage.getItem(VIEWER_KEY) || DEFAULT_VIEWER;
+    this.selectedKey = localStorage.getItem(VIEWER_KEY);
   } catch (error) {
     console.error('Failed to load viewer profile: %s', error);
   }
+  
+  //If none exists, or if localstorage is unavailable, use the default key.
+  if (!this.selectedKey) {
+    this.selectedKey = DEFAULT_VIEWER; 
+  }
+  
   this.dialog = this.createDialog_(DeviceInfo.Viewers);
   this.root = null;
 }


### PR DESCRIPTION
Before, `this.selectedKey` would be `undefined` if `localStorage.getItem()` threw an error (such as if the user has disabled localStorage, is in Private mode, etc.).

This commit assigns the `DEFAULT_VIEWER` value in the cases of `localStorage.getItem()` returning `undefined` AND throwing an Error.

---

Without this, the viewer is also left `undefined`, and everything depending on it, such as creating new distortions (`this.distortion = new Distortion(this.viewer.distortionCoefficients)`) breaks. This has been the cause of issues for a few dozen users over the last few months.