### PR TITLE
avoid errors if e.touches is absent

### DIFF
--- a/src/touch-panner.js
+++ b/src/touch-panner.js
@@ -45,7 +45,7 @@ TouchPanner.prototype.resetSensor = function() {
 
 TouchPanner.prototype.onTouchStart_ = function(e) {
   // Only respond if there is exactly one touch.
-  if (e.touches.length != 1) {
+  if (!e.touches || e.touches.length != 1) {
     return;
   }
   this.rotateStart.set(e.touches[0].pageX, e.touches[0].pageY);


### PR DESCRIPTION
redone fix per discussion on googlevr/webvr-polyfill#215, aframevr/webvr-polyfill#4 and aframevr/aframe#2669, to isolate change for PRs to both aframevr and googlevr