### PR TITLE
bring back node 4 regression testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "node"
   - "6"
+  - "4"
 
 cache:
   directories:

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const expect = require('chai').expect;
 const jsdom = require('jsdom');


### PR DESCRIPTION
At least one project consuming this in node supports all maintained node versions. Node 4 is still maintained https://github.com/nodejs/LTS#lts-schedule1. @jsantell could I convince you to keep regression testing node 4, so that any consumers don't unintentionally break?