### PR TITLE
bundle jsdom for window mocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   "description": "Use WebVR today, on mobile or desktop, without requiring a special browser build.",
   "dependencies": {
     "eventemitter3": "^2.0.2",
+    "jsdom": "^9.12.0",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "browserify": "latest",
     "chai": "^3.5.0",
     "derequire": "latest",
-    "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
     "watchify": "latest",
     "uglify-js": "^3.0.11"

--- a/src/node-entry.js
+++ b/src/node-entry.js
@@ -1,8 +1,7 @@
-// if running in node and there is a window mock available,
-// globalize its members where needed
-if (global && global.window) {
-  global.document = global.window.document;
-  global.navigator = global.window.navigator;
-}
+const jsdom = require('jsdom');
+
+global.window = jsdom.jsdom().defaultView;
+global.document = window.document;
+global.navigator = window.navigator;
 
 require('./main');

--- a/test/index.js
+++ b/test/index.js
@@ -2,17 +2,8 @@
 
 const path = require('path');
 const expect = require('chai').expect;
-const jsdom = require('jsdom');
 
 describe('node acceptance tests', function() {
-  beforeEach(function() {
-    global.window = jsdom.jsdom().defaultView;
-  });
-
-  afterEach(function() {
-    delete global.window;
-  });
-
   it('can run in node', function() {
     require(path.join(process.cwd(), 'src', 'node-entry'));
 


### PR DESCRIPTION
This is the final step to make running this polyfill in node a seemless experience. Previously, you would have to supply your own `window` implementation (jsdom) if you wanted to consume this. After this change, you get jsdom's window mocking for free, and all you have to do to use this is `require('webvr-polyfill')`