### PR TITLE
Remove dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
     "Jordan Santell <jordan@jsantell.com>"
   ],
   "description": "Use WebVR today, on mobile or desktop, without requiring a special browser build.",
-  "dependencies": {
-    "eventemitter3": "^2.0.2",
-    "object-assign": "^4.0.1"
-  },
   "devDependencies": {
     "chai": "^3.5.0",
     "jsdom": "^9.12.0",

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -47,7 +47,7 @@ function CardboardVRDisplay() {
   this.deviceInfo_ = new DeviceInfo(this.dpdb_.getDeviceParams());
 
   this.viewerSelector_ = new ViewerSelector();
-  this.viewerSelector_.on('change', this.onViewerChanged_.bind(this));
+  this.viewerSelector_.onChange(this.onViewerChanged_.bind(this));
 
   // Set the correct initial viewer.
   this.deviceInfo_.setViewer(this.viewerSelector_.getCurrentViewer());

--- a/src/util.js
+++ b/src/util.js
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-var objectAssign = require('object-assign');
-
 var Util = window.Util || {};
 
 Util.MIN_TIMESTEP = 0.001;
@@ -205,7 +203,15 @@ Util.isMobile = function() {
   return check;
 };
 
-Util.extend = objectAssign;
+Util.extend = function(dest, src) {
+  for (var key in src) {
+    if (src.hasOwnProperty(key)) {
+      dest[key] = src[key];
+    }
+  }
+
+  return dest;
+}
 
 Util.safariCssSizeWorkaround = function(canvas) {
   // TODO(smus): Remove this workaround when Safari for iOS is fixed.

--- a/src/viewer-selector.js
+++ b/src/viewer-selector.js
@@ -14,7 +14,6 @@
  */
 
 var DeviceInfo = require('./device-info.js');
-var EventEmitter3 = require('eventemitter3');
 var Util = require('./util.js');
 
 var DEFAULT_VIEWER = 'CardboardV1';
@@ -33,16 +32,16 @@ function ViewerSelector() {
   } catch (error) {
     console.error('Failed to load viewer profile: %s', error);
   }
-  
+
   //If none exists, or if localstorage is unavailable, use the default key.
   if (!this.selectedKey) {
-    this.selectedKey = DEFAULT_VIEWER; 
+    this.selectedKey = DEFAULT_VIEWER;
   }
-  
+
   this.dialog = this.createDialog_(DeviceInfo.Viewers);
   this.root = null;
+  this.onChangeCallbacks_ = [];
 }
-ViewerSelector.prototype = new EventEmitter3();
 
 ViewerSelector.prototype.show = function(root) {
   this.root = root;
@@ -76,6 +75,16 @@ ViewerSelector.prototype.getSelectedKey_ = function() {
   return null;
 };
 
+ViewerSelector.prototype.onChange = function(cb) {
+  this.onChangeCallbacks_.push(cb);
+};
+
+ViewerSelector.prototype.fireOnChange_ = function(viewer) {
+  for (var i = 0; i < this.onChangeCallbacks_.length; i++) {
+    this.onChangeCallbacks_[i](viewer);
+  }
+};
+
 ViewerSelector.prototype.onSave_ = function() {
   this.selectedKey = this.getSelectedKey_();
   if (!this.selectedKey || !DeviceInfo.Viewers[this.selectedKey]) {
@@ -83,7 +92,7 @@ ViewerSelector.prototype.onSave_ = function() {
     return;
   }
 
-  this.emit('change', DeviceInfo.Viewers[this.selectedKey]);
+  this.fireOnChange_(DeviceInfo.Viewers[this.selectedKey]);
 
   // Attempt to save the viewer profile, but fails in private mode.
   try {


### PR DESCRIPTION
Remove object-assign and eventemitter3 dependencies in lieu of inline, lighter functionality, and easier integration with Google build systems.