### PR TITLE
Fire 'vrdisplayconnect' event when populating VRDisplays. Fixes #40

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -342,6 +342,14 @@ VRDisplay.prototype.fireVRDisplayPresentChange_ = function() {
   window.dispatchEvent(event);
 };
 
+VRDisplay.prototype.fireVRDisplayConnect_ = function() {
+  // Important: unfortunately we cannot have full spec compliance here.
+  // CustomEvent custom fields all go under e.detail (so the VRDisplay ends up
+  // being e.detail.display, instead of e.display as per WebVR spec).
+  var event = new CustomEvent('vrdisplayconnect', {detail: {display: this}});
+  window.dispatchEvent(event);
+};
+
 VRDisplay.prototype.addFullscreenListeners_ = function(element, changeHandler, errorHandler) {
   this.removeFullscreenListeners_();
 

--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -54,6 +54,11 @@ WebVRPolyfill.prototype.isDeprecatedWebVRAvailable = function() {
   return ('getVRDevices' in navigator) || ('mozGetVRDevices' in navigator);
 };
 
+WebVRPolyfill.prototype.connectDisplay = function(vrDisplay) {
+  vrDisplay.fireVRDisplayConnect_();
+  this.displays.push(vrDisplay);
+};
+
 WebVRPolyfill.prototype.populateDevices = function() {
   if (this.devicesPopulated) {
     return;
@@ -65,7 +70,8 @@ WebVRPolyfill.prototype.populateDevices = function() {
   // Add a Cardboard VRDisplay on compatible mobile devices
   if (this.isCardboardCompatible()) {
     vrDisplay = new CardboardVRDisplay();
-    this.displays.push(vrDisplay);
+
+    this.connectDisplay(vrDisplay);
 
     // For backwards compatibility
     if (window.WebVRConfig.ENABLE_DEPRECATED_API) {
@@ -77,7 +83,7 @@ WebVRPolyfill.prototype.populateDevices = function() {
   // Add a Mouse and Keyboard driven VRDisplay for desktops/laptops
   if (!this.isMobile() && !window.WebVRConfig.MOUSE_KEYBOARD_CONTROLS_DISABLED) {
     vrDisplay = new MouseKeyboardVRDisplay();
-    this.displays.push(vrDisplay);
+    this.connectDisplay(vrDisplay);
 
     // For backwards compatibility
     if (window.WebVRConfig.ENABLE_DEPRECATED_API) {


### PR DESCRIPTION
Note, `vrdisplaydisconnect` doesn't apply here as there's no way to remove a shim VRDisplay anyway.