### PR TITLE
Skip polyfilled `VRFrameData` if object passed to `getFrameData` is native

### DIFF
--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -108,11 +108,17 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
 
   // Polyfill native VRDisplay.getFrameData
   if (this.nativeWebVRAvailable && window.VRFrameData) {
+    var NativeVRFrameData = window.VRFrameData;
     var nativeFrameData = new window.VRFrameData();
     var nativeGetFrameData = window.VRDisplay.prototype.getFrameData;
     window.VRFrameData = VRFrameData;
 
     window.VRDisplay.prototype.getFrameData = function(frameData) {
+      if (frameData instanceof NativeVRFrameData) {
+        nativeGetFrameData.call(this, frameData);
+        return;
+      }
+
       /*
       Copy frame data from the native object into the polyfilled object.
       */
@@ -228,6 +234,8 @@ WebVRPolyfill.prototype.getVRDevices = function() {
     }
   });
 };
+
+WebVRPolyfill.prototype.NativeVRFrameData = window.VRFrameData;
 
 /**
  * Determine if a device is mobile.


### PR DESCRIPTION
To operate properly, the polyfill needs to load and run as early as possible. Even if WebVR API is available, `VRFrameData` is polyfilled in case the browser provides no displays and we need to create a polyfilled Cardboard display.

This patch fixes the case where a native `VRFrameData` instance is created before the polyfill can be applied. `VRDisplay.prototype.getFrameData` now checks its argument so it doesn't try to set the read-only `pose` property on a native object.

I've also taken the liberty of adding a reference to the original un-polyfilled `VRFrameData` as `WebVRPolyfill.prototype.NativeVRFrameData` in case someone wants to reference it.

Fixes #263