### PR TITLE
Disable Host Check

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
       path.resolve(__dirname, 'examples'),
     ],
     host: '0.0.0.0',
+    disableHostCheck: true
   },
   plugins: [
     new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
It seems that WebPack tightened the security and the dev workflow I'm used to does not work anymore.
`npm start` and visiting `localhost:8080` locally or the `ip.of.my.server:8080` from a machine in my network returns an `Invalid Host header` error message. This PR disables the security host check on the `package.json` and everything works as it used to on my Windows boxes. The implications go a bit over my head so feel free to suggest an alternative. I found some literature here:

https://github.com/webpack/webpack-dev-server/issues/887
https://github.com/webpack/webpack-dev-server/issues/147#issuecomment-298816237