### PR TITLE
Fix fusion-pose-sensor.js for Firefox on Android

### DIFF
--- a/src/sensor-fusion/fusion-pose-sensor.js
+++ b/src/sensor-fusion/fusion-pose-sensor.js
@@ -132,11 +132,6 @@ FusionPoseSensor.prototype.updateDeviceMotion_ = function(deviceMotion) {
   var rotRate = deviceMotion.rotationRate;
   var timestampS = deviceMotion.timeStamp / 1000;
 
-  // Firefox Android timeStamp returns one thousandth of a millisecond.
-  if (this.isFirefoxAndroid) {
-    timestampS /= 1000;
-  }
-
   var deltaS = timestampS - this.previousTimestampS;
   if (deltaS <= Util.MIN_TIMESTEP || deltaS > Util.MAX_TIMESTEP) {
     console.warn('Invalid timestamps detected. Time step between successive ' +


### PR DESCRIPTION
Firefox for android returns the timestamp correctly now so there is no need to divide by 1000 any more.