### PR TITLE
only run polyfill if nativeWebVR is not available

### DIFF
--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -36,7 +36,7 @@ function WebVRPolyfill() {
                                  navigator.getVRDisplays :
                                  null;
 
-  if (!this.nativeLegacyWebVRAvailable) {
+  if (!this.nativeLegacyWebVRAvailable && !this.nativeWebVRAvailable) {
     this.enablePolyfill();
     if (window.WebVRConfig.ENABLE_DEPRECATED_API) {
       this.enableDeprecatedPolyfill();


### PR DESCRIPTION
If you run the polyfill when native VR is available, you won't be able to put the player into VR mode properly. This should fix https://github.com/borismus/webvr-boilerplate/issues/170 and https://github.com/videojs/videojs-vr/issues/14