### PR TITLE
prevent redefinition of navigator.vrEnabled

### DIFF
--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -137,7 +137,7 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
   window.VRDisplay = VRDisplay;
 
   // Provide the `navigator.vrEnabled` property.
-  if (navigator && !navigator.vrEnabled) {
+  if (navigator && !navigator.hasOwnProperty('vrEnabled')) {
     var self = this;
     Object.defineProperty(navigator, 'vrEnabled', {
       get: function () {


### PR DESCRIPTION
This tripped me up today. I don't think we want to redefine the property if it is `false`. If we do, then we should instead set `writable: true` in defineProperty()'s third argument.