### PR TITLE
Make polyfill work with ODG R-7 Web Browser

### DIFF
--- a/src/sensor-fusion/fusion-pose-sensor.js
+++ b/src/sensor-fusion/fusion-pose-sensor.js
@@ -139,7 +139,11 @@ FusionPoseSensor.prototype.updateDeviceMotion_ = function(deviceMotion) {
     this.previousTimestampS = timestampS;
     return;
   }
+
   this.accelerometer.set(-accGravity.x, -accGravity.y, -accGravity.z);
+  if (Util.isR7()) {
+    this.gyroscope.set(-rotRate.beta, rotRate.alpha, rotRate.gamma);
+  } else
   this.gyroscope.set(rotRate.alpha, rotRate.beta, rotRate.gamma);
 
   // With iOS and Firefox Android, rotationRate is reported in degrees,

--- a/src/sensor-fusion/fusion-pose-sensor.js
+++ b/src/sensor-fusion/fusion-pose-sensor.js
@@ -143,8 +143,9 @@ FusionPoseSensor.prototype.updateDeviceMotion_ = function(deviceMotion) {
   this.accelerometer.set(-accGravity.x, -accGravity.y, -accGravity.z);
   if (Util.isR7()) {
     this.gyroscope.set(-rotRate.beta, rotRate.alpha, rotRate.gamma);
-  } else
-  this.gyroscope.set(rotRate.alpha, rotRate.beta, rotRate.gamma);
+  } else {
+    this.gyroscope.set(rotRate.alpha, rotRate.beta, rotRate.gamma);
+  }
 
   // With iOS and Firefox Android, rotationRate is reported in degrees,
   // so we first convert to radians.

--- a/src/util.js
+++ b/src/util.js
@@ -80,8 +80,16 @@ Util.isFirefoxAndroid = (function() {
   };
 })();
 
+Util.isR7 = (function() {
+  var isR7 = navigator.userAgent.indexOf('R7 Build') !== -1;
+  return function() {
+    return isR7;
+  };
+})();
+
 Util.isLandscapeMode = function() {
-  return (window.orientation == 90 || window.orientation == -90);
+  var rtn = (window.orientation == 90 || window.orientation == -90);
+  return Util.isR7() ? !rtn : rtn;
 };
 
 // Helper method to validate the time steps of sensor timestamps.


### PR DESCRIPTION
The changes here make the accelerometer / gyroscope based sensor fusion work properly on the latest Web Browser for the ODG R-7, which is a landscape-primary device.