### PR TITLE
Re-add Util.getQuaternionAngle to fix debug mode

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -478,4 +478,15 @@ Util.getDomainFromUrl = function(url) {
   return domain;
 }
 
+Util.getQuaternionAngle = function(quat) {
+  // angle = 2 * acos(qw)
+  // If w is greater than 1 (THREE.js, how can this be?), arccos is not defined.
+  if (quat.w > 1) {
+    console.warn('getQuaternionAngle: w > 1');
+    return 0;
+  }
+  var angle = 2 * Math.acos(quat.w);
+  return angle;
+};
+
 module.exports = Util;


### PR DESCRIPTION
When debug mode is activated on mobile devices, the polyfill throws a lot of errors:
```
Uncaught TypeError: Util.getQuaternionAngle is not a function
    at ComplementaryFilter.run_ (webvr-polyfill.js:4237)
    at ComplementaryFilter.addGyroMeasurement (webvr-polyfill.js:4190)
    at FusionPoseSensor.updateDeviceMotion_ (webvr-polyfill.js:4039)
    at FusionPoseSensor.onDeviceMotion_ (webvr-polyfill.js:4009)
```
Steps to reproduce:
1. Open http://googlevr.github.io/webvr-polyfill/examples/basic/?debug=true in Chrome on Android
2. Attach a remote Chrome debugger
3. Click the VR button

It appears that `Util.getQuaternionAngle` was (accidentally) removed some time [after v0.2.6](https://github.com/googlevr/webvr-polyfill/blob/v0.2.6/fusion/util.js), but it was still used in debug mode. This PR re-adds this missing function.