### PR TITLE
Remove CardboardVRDisplay onvrdisplayconnect event, fixes #258

### DIFF
--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -64,7 +64,6 @@ WebVRPolyfill.prototype.getPolyfillDisplays = function() {
       DIRTY_SUBMIT_FRAME_BINDINGS:  this.config.DIRTY_SUBMIT_FRAME_BINDINGS,
     });
 
-    vrDisplay.fireVRDisplayConnect_();
     this.polyfillDisplays.push(vrDisplay);
   }
 


### PR DESCRIPTION
@brianchirls removing this fixes the issue in #258, and there are some other concerns regarding events there (maybe move into a new thread?), but this should do the trick on the connection event for the CardboardVRDisplay, whether or not it actually gets used